### PR TITLE
Use regex.test(str) instead of str.match(regex)

### DIFF
--- a/modules/isPrefixedProperty.js
+++ b/modules/isPrefixedProperty.js
@@ -2,5 +2,5 @@
 const regex = /^(Webkit|Moz|O|ms)/
 
 export default function isPrefixedProperty(property: string): boolean {
-  return property.match(regex) !== null
+  return regex.test(property)
 }

--- a/modules/isPrefixedValue.js
+++ b/modules/isPrefixedValue.js
@@ -2,5 +2,5 @@
 const regex = /-webkit-|-moz-|-ms-/
 
 export default function isPrefixedValue(value: any): boolean {
-  return typeof value === 'string' && value.match(regex) !== null
+  return typeof value === 'string' && regex.test(value)
 }


### PR DESCRIPTION
In both of these places, we really care about a boolean regex match so
we can use the much faster regex.test instead of str.match.

https://jsperf.com/str-match-vs-regex-test/1