### PR TITLE
Add babel-cli to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "hyphenate-style-name": "^1.0.2"
   },
   "devDependencies": {
+    "babel-cli": "^6.22.1",
     "babel-core": "^6.22.1",
     "babel-eslint": "^7.1.1",
     "babel-jest": "^18.0.0",


### PR DESCRIPTION
This is required to run the babel script and actually build this
package.