### PR TITLE
Fix redundant values when merging arrays

### DIFF
--- a/modules/__tests__/assignStyle-test.js
+++ b/modules/__tests__/assignStyle-test.js
@@ -75,4 +75,31 @@ describe('Assinging styles', () => {
       foo: 'bar'
     })
   })
+
+  it('should overwrite previous values when both values are array', () => {
+    const ob1 = { fontSize: ['10px', '10rem'] }
+    const ob2 = { fontSize: ['10px', '20vw'] }
+
+    const newOb = assignStyle({}, ob1, ob2)
+
+    expect(newOb).toEqual({ fontSize: ['10px', '20vw'] })
+  })
+
+  it('should overwrite previous values when only the last value is an array', () => {
+    const ob1 = { fontSize: 10 }
+    const ob2 = { fontSize: ['10px', '20vw'] }
+
+    const newOb = assignStyle({}, ob1, ob2)
+
+    expect(newOb).toEqual({ fontSize: ['10px', '20vw'] })
+  })
+
+  it('should overwrite previous values when only the first value is an array', () => {
+    const ob1 = { fontSize: ['10px', '10rem'] }
+    const ob2 = { fontSize: 20 }
+
+    const newOb = assignStyle({}, ob1, ob2)
+
+    expect(newOb).toEqual({ fontSize: 20 })
+  })
 })

--- a/modules/assignStyle.js
+++ b/modules/assignStyle.js
@@ -7,20 +7,9 @@ export default function assignStyle(base: Object, ...extendingStyles: Array<Obje
       const value = style[property]
       const baseValue = base[property]
 
-      if (typeof baseValue === 'object') {
-        if (Array.isArray(baseValue)) {
-          if (Array.isArray(value)) {
-            base[property] = [...baseValue, ...value]
-          } else {
-            base[property] = [...baseValue, value]
-          }
-          continue
-        }
-
-        if (typeof value === 'object' && !Array.isArray(value)) {
-          base[property] = assignStyle({}, baseValue, value)
-          continue
-        }
+      if (typeof value === 'object' && !Array.isArray(value)) {
+        base[property] = assignStyle({}, baseValue, value)
+        continue
       }
 
       base[property] = value


### PR DESCRIPTION
As reported in rofrischmann/fela#356, arrays of values are concatenated
instead of being replaced by one another, as is the case with other
non-object values. This causes output of redundant rules when using
`fela-plugin-fallback-value` together with `fela-plugin-extend`.