### PR TITLE
Integrated isObject into assignStyle

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ By now I have authored and collaborated on many different libraries and found I 
 * [`resolveArrayValue(property, value)`](#resolvearrayvalueproperty-value)
 * [`unprefixProperty(property)`](#unprefixpropertyproperty)
 * [`unprefixValue(value)`](#unprefixvaluevalue)
-*
+
 ------
 
 ### `assignStyle(base, ...extend)`

--- a/modules/__tests__/assignStyle-test.js
+++ b/modules/__tests__/assignStyle-test.js
@@ -102,4 +102,16 @@ describe('Assinging styles', () => {
 
     expect(newOb).toEqual({ fontSize: 20 })
   })
+
+  it('should not recursively call assignStyle for null values', () => {
+    const ob1 = { fontSize: 10 }
+    const ob2 = { margin: null }
+
+    const newOb = assignStyle({}, ob1, ob2)
+
+    expect(newOb).toEqual({
+      fontSize: 10,
+      margin: null
+    })
+  })
 })

--- a/modules/assignStyle.js
+++ b/modules/assignStyle.js
@@ -1,4 +1,6 @@
 /* @flow */
+import isPlainObject from 'isobject'
+
 export default function assignStyle(base: Object, ...extendingStyles: Array<Object>) {
   for (let i = 0, len = extendingStyles.length; i < len; ++i) {
     const style = extendingStyles[i]
@@ -7,7 +9,7 @@ export default function assignStyle(base: Object, ...extendingStyles: Array<Obje
       const value = style[property]
       const baseValue = base[property]
 
-      if (typeof value === 'object' && !Array.isArray(value)) {
+      if (isPlainObject(value)) {
         base[property] = assignStyle({}, baseValue, value)
         continue
       }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
         "rootDir": "modules"
     },
     "dependencies": {
-        "hyphenate-style-name": "^1.0.2"
+        "hyphenate-style-name": "^1.0.2",
+        "isobject": "^3.0.1"
     },
     "devDependencies": {
         "babel-cli": "^6.22.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2300,6 +2300,10 @@ isobject@^2.0.0:
   dependencies:
     isarray "1.0.0"
 
+isobject@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
+
 isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"


### PR DESCRIPTION
This PR fixes cases where a style value is set to `null`.

The previous type checking logic:

```js
if (typeof value === 'object' && !Array.isArray(value)) {
  base[property] = assignStyle({}, baseValue, value)
}
```

...meant that `null` values passed this test and the `assignStyle` function was being called again, setting the value of that property to an empty object:

```js
assignStyle({}, { color: null }) // { color: {} }
```

This bug has already been raised and fixed across a number of Fela packages following this issue:

https://github.com/rofrischmann/fela/issues/525

...this PR fixes the same issue in these CSS in JS utils which Fela uses internally.

I also removed a trailing `*` from the README that I noticed when reading them (I assume it's not meant to be there).